### PR TITLE
Update manifest details to work with MV3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,24 +1,39 @@
 {
-    "version": "1.1.4",
-	"manifest_version": 2,
-	"name": "OpenLaw NZ Legislation helper",
-	"description":
-		"Access the OpenLaw NZ database from within legislation.govt.nz",
-	"icons": {
-		"16": "logo.png",
-		"128": "logo.png"
-	},
-	"permissions": [],
-    "web_accessible_resources": [
-		"logo.png"
-	],
-	"minimum_chrome_version": "22",
-
-	"content_scripts": [
-		{
-			"matches": ["http://legislation.govt.nz/act/private/*", "http://legislation.govt.nz/act/public/*", "http://www.legislation.govt.nz/act/public/*", "http://www.legislation.govt.nz/act/private/*", "https://legislation.govt.nz/act/private/*", "https://legislation.govt.nz/act/public/*", "https://www.legislation.govt.nz/act/public/*", "https://www.legislation.govt.nz/act/private/*"],
-			"js": ["inject.js"],
-			"css": ["inject.css"]
-		}
-	]
+  "version": "1.1.4",
+  "manifest_version": 3,
+  "name": "OpenLaw NZ Legislation helper",
+  "description": "Access the OpenLaw NZ database from within legislation.govt.nz",
+  "icons": {
+    "16": "logo.png",
+    "128": "logo.png"
+  },
+  "permissions": [],
+  "web_accessible_resources": [
+    {
+      "resources": ["logo.png"],
+      "matches": [
+        "http://legislation.govt.nz/*",
+        "http://www.legislation.govt.nz/*",
+        "https://legislation.govt.nz/*",
+        "https://www.legislation.govt.nz/*"
+      ]
+    }
+  ],
+  "minimum_chrome_version": "88",
+  "content_scripts": [
+    {
+      "matches": [
+        "http://legislation.govt.nz/act/private/*",
+        "http://legislation.govt.nz/act/public/*",
+        "http://www.legislation.govt.nz/act/public/*",
+        "http://www.legislation.govt.nz/act/private/*",
+        "https://legislation.govt.nz/act/private/*",
+        "https://legislation.govt.nz/act/public/*",
+        "https://www.legislation.govt.nz/act/public/*",
+        "https://www.legislation.govt.nz/act/private/*"
+      ],
+      "js": ["inject.js"],
+      "css": ["inject.css"]
+    }
+  ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,39 +1,39 @@
 {
-  "version": "1.1.5",
-  "manifest_version": 3,
-  "name": "OpenLaw NZ Legislation helper",
-  "description": "Access the OpenLaw NZ database from within legislation.govt.nz",
-  "icons": {
-    "16": "logo.png",
-    "128": "logo.png"
-  },
-  "permissions": [],
-  "web_accessible_resources": [
-    {
-      "resources": ["logo.png"],
-      "matches": [
-        "http://legislation.govt.nz/*",
-        "http://www.legislation.govt.nz/*",
-        "https://legislation.govt.nz/*",
-        "https://www.legislation.govt.nz/*"
-      ]
-    }
-  ],
-  "minimum_chrome_version": "88",
-  "content_scripts": [
-    {
-      "matches": [
-        "http://legislation.govt.nz/act/private/*",
-        "http://legislation.govt.nz/act/public/*",
-        "http://www.legislation.govt.nz/act/public/*",
-        "http://www.legislation.govt.nz/act/private/*",
-        "https://legislation.govt.nz/act/private/*",
-        "https://legislation.govt.nz/act/public/*",
-        "https://www.legislation.govt.nz/act/public/*",
-        "https://www.legislation.govt.nz/act/private/*"
-      ],
-      "js": ["inject.js"],
-      "css": ["inject.css"]
-    }
-  ]
+    "version": "1.1.5",
+    "manifest_version": 3,
+    "name": "OpenLaw NZ Legislation helper",
+    "description": "Access the OpenLaw NZ database from within legislation.govt.nz",
+    "icons": {
+        "16": "logo.png",
+        "128": "logo.png"
+    },
+    "permissions": [],
+    "web_accessible_resources": [
+        {
+            "resources": ["logo.png"],
+            "matches": [
+                "http://legislation.govt.nz/*",
+                "http://www.legislation.govt.nz/*",
+                "https://legislation.govt.nz/*",
+                "https://www.legislation.govt.nz/*"
+            ]
+        }
+    ],
+    "minimum_chrome_version": "88",
+    "content_scripts": [
+        {
+            "matches": [
+                "http://legislation.govt.nz/act/private/*",
+                "http://legislation.govt.nz/act/public/*",
+                "http://www.legislation.govt.nz/act/public/*",
+                "http://www.legislation.govt.nz/act/private/*",
+                "https://legislation.govt.nz/act/private/*",
+                "https://legislation.govt.nz/act/public/*",
+                "https://www.legislation.govt.nz/act/public/*",
+                "https://www.legislation.govt.nz/act/private/*"
+            ],
+            "js": ["inject.js"],
+            "css": ["inject.css"]
+        }
+    ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "manifest_version": 3,
   "name": "OpenLaw NZ Legislation helper",
   "description": "Access the OpenLaw NZ database from within legislation.govt.nz",


### PR DESCRIPTION
This is a reasonably straight forward PR to update the manifest version so that this extension remains available on Chrome. There is some general formatting applied for consistent spacing.

Changes in the order they appear:

- `version` is incremented as a patch version for convenience, but not required to make this work.
- `manifest_version` is updated to version 3.
- `web_accessible_resources` is updated to include match patterns as per the new manifest requirements ([See here](https://developer.chrome.com/docs/extensions/develop/migrate/manifest#update-wa-resources)), and see the information [here](https://developer.chrome.com/docs/extensions/reference/manifest/web-accessible-resources), under the `matches` property for why wildcard paths are needed.
- `minimum_chrome_version` is updated to 88. This is the minimum version required to use Manifest V3, and therefore the chrome web store itself ([See here](https://developer.chrome.com/docs/extensions/develop/migrate#:~:text=Manifest%20V3%20is%20supported%20generally%20in%20Chrome%2088%20or%20later.,-When%20updating%20API))

